### PR TITLE
Check for <bluetooth/bluetooth.h> presence during configure.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_CHECK_LIB([pthread], pthread_create, [], [AC_MSG_ERROR([pthread library not f
 AC_CHECK_LIB([glib-2.0], g_variant_new, [], [AC_MSG_ERROR([glib-2.0 library not found])])
 AC_CHECK_LIB([gio-2.0], g_dbus_method_invocation_return_dbus_error, [], [AC_MSG_ERROR([gio-2.0 library not found])])
 AC_CHECK_LIB([gobject-2.0], g_object_unref, [], [AC_MSG_ERROR([gobject-2.0 library not found])])
+AC_CHECK_HEADER([bluetooth/bluetooth.h], [], [AC_MSG_ERROR([bluetooth/bluetooth.h header not found])])
 AX_CXX_COMPILE_STDCXX(11)
 AC_PROG_RANLIB
 AC_PROG_CXX


### PR DESCRIPTION
To avoid build error on absence of included <bluetooth/bluetooth.h> file
during make stage check for this file in configure stage.

This will avoid following build error.

g++ -DHAVE_CONFIG_H -I. -I..    -fPIC -Wall -Wextra -std=c++11 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -pthread -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/uuid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -g -O2 -MT libggk_a-HciSocket.o -MD -MP -MF .deps/libggk_a-HciSocket.Tpo -c -o libggk_a-HciSocket.o `test -f 'HciSocket.cpp' || echo './'`HciSocket.cpp
HciSocket.cpp:33:10: fatal error: bluetooth/bluetooth.h: No such file or directory
 #include <bluetooth/bluetooth.h>
          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [Makefile:601: libggk_a-HciSocket.o] Error 1
make[2]: Leaving directory '/home/user/packages/gobbledegook/src'
make[1]: *** [Makefile:368: all-recursive] Error 1
make[1]: Leaving directory '/home/user/packages/gobbledegook'
make: *** [Makefile:309: all] Error 2