### PR TITLE
Ability to read large data from offsets if requested from device

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -382,6 +382,8 @@ Server::Server(const std::string &serviceName, const std::string &advertisingNam
 			.onReadValue(CHARACTERISTIC_METHOD_CALLBACK_LAMBDA
 			{
 				const char *pTextString = self.getDataPointer<const char *>("text/string", "");
+				// for longer data, the reading device may ask to read starting at an offset (i.e, iOS devices read in 184 byte chunks)
+				pTextString += ServerUtils::getOffsetFromParameters(pParameters, strlen(pTextString));
 				self.methodReturnValue(pInvocation, pTextString, true);
 			})
 

--- a/src/ServerUtils.h
+++ b/src/ServerUtils.h
@@ -34,6 +34,9 @@ struct ServerUtils
 	// Builds the response to the method call `GetManagedObjects` from the D-Bus interface `org.freedesktop.DBus.ObjectManager`
 	static void getManagedObjects(GDBusMethodInvocation *pInvocation);
 
+	// Devices will sometimes perform reads on long buffers in multiple chunks, this returns an offset if that occurs.
+	static uint16_t getOffsetFromParameters(GVariant *params, uint16_t dataLength);
+
 	// WARNING: Hacky code - don't count on this working properly on all systems
 	//
 	// This routine will attempt to parse /proc/cpuinfo to return the CPU count/model. Results are cached on the first call, with


### PR DESCRIPTION
I encountered problems reading a 220 byte string on iOS. It worked fine on Android, and after debugging I found out that BlueZ is returning some pParameters in the Method callback, mainly "offset" appeared.

This is just a simple method to look for the "offset" parameter and also a piece of example code of it being applied. You should only need to call getOffsetFromParameters() if the data being returned (either byte array or c-string) can be pretty large. afaik iOS is the only OS that actually breaks reads up like this (at 184 byte intervals), everything else just uses the HCI automatic packet chunking (even my Galaxy S6 worked on data over 4Kbs).