### PR TITLE
Update Utils.cpp

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -421,9 +421,8 @@ std::string Utils::stringFromGVariantByteArray(const GVariant *pVariant)
 {
 	gsize size;
 	gconstpointer pPtr = g_variant_get_fixed_array(const_cast<GVariant *>(pVariant), &size, 1);
-	std::vector<gchar> array(size + 1, 0);
-	memcpy(array.data(), pPtr, size);
-	return array.data();
+	std::string str((char*)pPtr, size);
+	return str;
 }
 
 }; // namespace ggk


### PR DESCRIPTION
fixed issue: truncated data when \0 is in the array which is not the end